### PR TITLE
src/s6-linux-utils/rngseed.c: fix build with glibc <

### DIFF
--- a/src/s6-linux-utils/rngseed.c
+++ b/src/s6-linux-utils/rngseed.c
@@ -12,7 +12,9 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+#ifdef SKALIBS_HASGETRANDOM
 #include <sys/random.h>
+#endif
 #include <linux/random.h>
 
 #include <skalibs/types.h>


### PR DESCRIPTION
`getrandom` and `sys/random.h` are only available since glibc 2.25 resulting in the following build failure  since version 2.6.0.0 and https://github.com/skarnet/s6-linux-utils/commit/ad5973028c42d947440cdae5e4f106152c3dda28:

```
src/minutils/rngseed.c:15:24: fatal error: sys/random.h: No such file or directory
 #include <sys/random.h>
                        ^
```

Fixes:
 - http://autobuild.buildroot.org/results/214bcecfc389cb412b68627c831300478d614a3a